### PR TITLE
only set cache-control headers for success response

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var onHeaders = require('on-headers');
 var globject = require('globject');
 var slasher = require('glob-slasher');
 var setCacheHeader = require('cache-header');
+var isSuccess = require('is-success')
 
 module.exports = function (cachePaths) {
 
@@ -14,10 +15,9 @@ module.exports = function (cachePaths) {
     var cacheValue = cacheValues(slasher(pathname));
 
     onHeaders(res, function () {
-
-      // Default value
-      res.setHeader('Cache-Control', 'no-cache');
-      setCacheHeader(res, cacheValue);
+      if (res.statusCode && isSuccess(res.statusCode)) {
+        setCacheHeader(res, cacheValue);
+      }
     });
 
     next();

--- a/index.js
+++ b/index.js
@@ -6,20 +6,20 @@ var slasher = require('glob-slasher');
 var setCacheHeader = require('cache-header');
 
 module.exports = function (cachePaths) {
-  
+
   return function (req, res, next) {
-    
+
     var pathname = url.parse(req.url).pathname;
     var cacheValues = globject(slasher(cachePaths || {}, {value: false}));
     var cacheValue = cacheValues(slasher(pathname));
-    
+
     onHeaders(res, function () {
-      
+
       // Default value
-      res.setHeader('Cache-Control', 'public, max-age=300');
+      res.setHeader('Cache-Control', 'no-cache');
       setCacheHeader(res, cacheValue);
     });
-    
+
     next();
   };
 };

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "fast-url-parser": "^1.0.6-0",
     "glob-slasher": "^1.0.1",
     "globject": "^1.0.0",
+    "is-success": "^1.0.0",
     "lodash.isnumber": "^2.4.1",
     "on-headers": "^1.0.0",
     "regular": "^0.1.6"

--- a/test/index.js
+++ b/test/index.js
@@ -10,75 +10,75 @@ var caches = {
 };
 
 describe('cache control middleware', function() {
-  
+
   var app;
-  
+
   beforeEach(function () {
-    
+
     app = connect()
       .use(cacheControl(caches));
   });
-  
+
   it('sets the max age cache header if specified in config file', function (done) {
-    
+
     request(app)
       .get('/index.html')
       .expect('Cache-Control', 'public, max-age=31536000')
       .end(done);
   });
-  
+
   it('sets cache control to no-cache if false is specified in config file', function (done) {
-    
+
     request(app)
       .get('/none.html')
       .expect('Cache-Control', 'no-cache')
       .end(done);
   });
-  
+
   it('sets cache control to the passed string if specified in config file', function (done) {
-    
+
     request(app)
       .get('/private.html')
       .expect('Cache-Control', 'private, max-age=300')
       .end(done);
   });
-  
-  it('sets cache control to 5 minutes? by default', function(done) {
-    
+
+  it('sets cache control to no-cache by default', function(done) {
+
     request(app)
       .get('/default.html')
-      .expect('Cache-Control', 'public, max-age=300')
+      .expect('Cache-Control', 'no-cache')
       .end(done);
   });
-  
-  it('sets the cache control to 5 minutes? by default if no config is provided', function (done) {
-    
+
+  it('sets the cache control to no-cache by default if no config is provided', function (done) {
+
     request(app)
       .get('/default.html')
-      .expect('Cache-Control', 'public, max-age=300')
+      .expect('Cache-Control', 'no-cache')
       .end(done);
   });
-  
+
   it('sets cache control using glob negation', function (done) {
-    
+
     var  app = connect()
       .use(cacheControl({
         '!/anything/**': 'negation'
       }));
-    
+
     async.parallel([
       function (cb) {
-        
+
         request(app)
           .get('/negation')
           .expect('Cache-Control', 'negation')
           .end(cb);
       },
       function (cb) {
-        
+
         request(app)
           .get('/anything/test.html')
-          .expect('Cache-Control', 'public, max-age=300')
+          .expect('Cache-Control', 'no-cache')
           .end(cb);
       }
     ], done);

--- a/test/index.js
+++ b/test/index.js
@@ -16,7 +16,11 @@ describe('cache control middleware', function() {
   beforeEach(function () {
 
     app = connect()
-      .use(cacheControl(caches));
+      .use(cacheControl(caches))
+      .use(function (req, res, next) {
+        res.statusCode = 200;
+        res.end('OK!');
+      });
   });
 
   it('sets the max age cache header if specified in config file', function (done) {
@@ -43,28 +47,16 @@ describe('cache control middleware', function() {
       .end(done);
   });
 
-  it('sets cache control to no-cache by default', function(done) {
-
-    request(app)
-      .get('/default.html')
-      .expect('Cache-Control', 'no-cache')
-      .end(done);
-  });
-
-  it('sets the cache control to no-cache by default if no config is provided', function (done) {
-
-    request(app)
-      .get('/default.html')
-      .expect('Cache-Control', 'no-cache')
-      .end(done);
-  });
-
   it('sets cache control using glob negation', function (done) {
 
     var  app = connect()
       .use(cacheControl({
         '!/anything/**': 'negation'
-      }));
+      }))
+      .use(function (req, res, next) {
+        res.statusCode = 200
+        res.end('OK!')
+      });
 
     async.parallel([
       function (cb) {
@@ -72,13 +64,6 @@ describe('cache control middleware', function() {
         request(app)
           .get('/negation')
           .expect('Cache-Control', 'negation')
-          .end(cb);
-      },
-      function (cb) {
-
-        request(app)
-          .get('/anything/test.html')
-          .expect('Cache-Control', 'no-cache')
           .end(cb);
       }
     ], done);


### PR DESCRIPTION
This pull request trying to fix two thing:
1. Remove default cache-control header https://github.com/divshot/cache-control/pull/1
2. Only set cache-control headers when the response statusCode is `2xx` as we don't want to cache error response in most case.
